### PR TITLE
Make LB deployment conditional and support precreated IAM roles

### DIFF
--- a/aws_resources.tf
+++ b/aws_resources.tf
@@ -17,8 +17,11 @@ resource "aws_ssm_parameter" "sidecar_client_secret" {
   type  = "SecureString"
 }
 
+
 # Role/Policy for ECS execution policy that gives the required access
 resource "aws_iam_role" "ecs_role" {
+  count = var.precreated_ecs_role_arn == null ? 1 : 0
+
   name = "cyral_sidecar_ecs_role"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -60,6 +63,9 @@ resource "aws_iam_role" "ecs_role" {
 }
 
 resource "aws_iam_role" "ecs_task_role" {
+  count = var.precreated_ecs_task_role_arn == null ? 1 : 0
+
+
   name = "cyral_sidecar_ecs_task_role"
   assume_role_policy = jsonencode({
     "Version" : "2012-10-17",
@@ -89,7 +95,8 @@ resource "aws_iam_role" "ecs_task_role" {
           ],
           "Resource" : [
             "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/cyral/*",
-            "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+            "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*",
+            "arn:aws:ecr:*"
           ]
         }
       ]

--- a/container_definition.tf
+++ b/container_definition.tf
@@ -1,5 +1,5 @@
 locals {
-  sidecar_endpoint = var.sidecar_dns_name != "" ? var.sidecar_dns_name : aws_lb.sidecar_nlb.dns_name
+  sidecar_endpoint = var.sidecar_dns_name != "" || length(aws_lb.sidecar_nlb) == 0 ? var.sidecar_dns_name : aws_lb.sidecar_nlb[0].dns_name
   container_definition = [
     {
       # The sidecar container name

--- a/output.tf
+++ b/output.tf
@@ -4,12 +4,12 @@ output "ecs_cluster_arn" {
 }
 
 output "load_balancer_arn" {
-  value       = aws_lb.sidecar_nlb.arn
+  value       = var.deploy_load_balancer ? aws_lb.sidecar_nlb[0].arn : null
   description = "Load balancer ARN"
 }
 
 output "load_balancer_dns" {
-  value       = aws_lb.sidecar_nlb.dns_name
+  value       = var.deploy_load_balancer ? aws_lb.sidecar_nlb[0].dns_name : null
   description = "Sidecar load balancer DNS endpoint"
 }
 

--- a/variables_aws.tf
+++ b/variables_aws.tf
@@ -42,3 +42,9 @@ variable "vpc_id" {
   description = "The VPC ID of the sidecar subnets."
   type        = string
 }
+
+variable "deploy_load_balancer" {
+  description = "Deploy or not the load balancer and target groups. This option makes the ASG have only one replica, irrelevant of the Asg Min Max and Desired"
+  type        = bool
+  default     = true
+}

--- a/variables_ecs.tf
+++ b/variables_ecs.tf
@@ -15,6 +15,19 @@ locals {
   }
 }
 
+# Variables to optionally provide pre-created IAM role ARNs
+variable "precreated_ecs_role_arn" {
+  type        = string
+  description = "ARN of the pre-created ECS role"
+  default     = null
+}
+
+variable "precreated_ecs_task_role_arn" {
+  type        = string
+  description = "ARN of the pre-created ECS task role"
+  default     = null
+}
+
 variable "container_registry" {
   description = "The container registry where the sidecar image is stored."
   default     = "public.ecr.aws/cyral"


### PR DESCRIPTION
Known issues: 
* When the Load Balancer is not deployed, we need to provide a sidecar endpoint to the template because we are currently unable to get the sidecar IP address from ECS.